### PR TITLE
fix: use the correct in type for discussion number

### DIFF
--- a/pkg/github/discussions.go
+++ b/pkg/github/discussions.go
@@ -348,7 +348,7 @@ func GetDiscussion(getClient GetClientFn, t translations.TranslationHelperFunc) 
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
-			discussionID, err := requiredParam[int](request, "discussion_id")
+			discussionID, err := RequiredInt(request, "discussion_id")
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
@@ -401,7 +401,7 @@ func GetDiscussionComments(getClient GetClientFn, t translations.TranslationHelp
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
-			discussionID, err := requiredParam[int](request, "discussion_id")
+			discussionID, err := RequiredInt(request, "discussion_id")
 			if err != nil {
 				return mcp.NewToolResultError(err.Error()), nil
 			}

--- a/pkg/github/discussions_test.go
+++ b/pkg/github/discussions_test.go
@@ -401,7 +401,7 @@ func Test_GetDiscussion(t *testing.T) {
 			requestArgs: map[string]interface{}{
 				"owner":         "owner",
 				"repo":          "repo",
-				"discussion_id": int(1),
+				"discussion_id": float64(1),
 			},
 			expectError:    false,
 			expectedResult: mockDiscussion,
@@ -423,7 +423,7 @@ func Test_GetDiscussion(t *testing.T) {
 			requestArgs: map[string]interface{}{
 				"owner":         "owner",
 				"repo":          "repo",
-				"discussion_id": int(999),
+				"discussion_id": float64(999),
 			},
 			expectError:    true,
 			expectedErrMsg: "failed to get discussion",
@@ -496,7 +496,7 @@ func Test_GetDiscussionComments(t *testing.T) {
 	request := createMCPRequest(map[string]interface{}{
 		"owner":         "owner",
 		"repo":          "repo",
-		"discussion_id": 1,
+		"discussion_id": float64(1),
 	})
 
 	result, err := handler(context.Background(), request)


### PR DESCRIPTION
<!--
    Thank you for contributing to GitHub MCP Server!
    Please reference an existing issue: `Closes #NUMBER`

    Screenshots or videos of changed behavior is incredibly helpful and always appreciated.
    Consider addressing the following:
    - Tradeoffs: List tradeoffs you made to take on or pay down tech debt.
    - Alternatives: Describe alternative approaches you considered and why you discarded them.
-->

Closes:
